### PR TITLE
fix: always show http protocol when https

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -197,13 +197,14 @@ function PluginInspect(options: Options = {}): Plugin {
       // hijack httpServer.listen to print the log
       const _listen = server.httpServer.listen
       let port = config.server.port || 3000
+      const protocol = config.server.https ? 'https' : 'http'
       let timer: any
       server.httpServer.listen = function(this: any, ...args: any) {
         port ||= args[0]
         clearTimeout(timer)
         timer = setTimeout(() => {
         // eslint-disable-next-line no-console
-          console.log(`  > Inspect: ${yellow(`http://localhost:${port}/__inspect/`)}\n`)
+          console.log(`  > Inspect: ${yellow(`${protocol}://localhost:${port}/__inspect/`)}\n`)
         }, 0)
         return _listen.apply(this, args)
       }


### PR DESCRIPTION
fix always show `http` protocol when `https`

```diff
--- Inspect: http://localhost:8801/__inspect/
+++ Inspect: https://localhost:8801/__inspect/
```