### PR TITLE
fix(client): size should be 100% when toggle two columns to one columns

### DIFF
--- a/src/client/components/DiffEditor.vue
+++ b/src/client/components/DiffEditor.vue
@@ -68,12 +68,10 @@ onMounted(() => {
     // clean up marks
     cm1.getAllMarks().forEach(i => i.clear())
     cm2.getAllMarks().forEach(i => i.clear())
-    new Array(cm1.lineCount() + 2)
-      .fill(null!)
-      .map((_, i) => cm1.removeLineClass(i, 'background', 'diff-removed'))
-    new Array(cm2.lineCount() + 2)
-      .fill(null!)
-      .map((_, i) => cm2.removeLineClass(i, 'background', 'diff-added'))
+    for (let i = 0; i < cm1.lineCount() + 2; i++)
+      cm1.removeLineClass(i, 'background', 'diff-removed')
+    for (let i = 0; i < cm2.lineCount() + 2; i++)
+      cm2.removeLineClass(i, 'background', 'diff-added')
 
     if (showDiff && from.value) {
       const changes = await calculateDiffWithWorker(l, r)
@@ -135,7 +133,7 @@ function onUpdate(size: number) {
     <Pane v-show="!showOneColumn" min-size="10" :size="leftPanelSize" class="h-max min-h-screen" border="main r">
       <textarea ref="fromEl" v-text="from" />
     </Pane>
-    <Pane min-size="10" class="h-max min-h-screen">
+    <Pane min-size="10" :size="100 - leftPanelSize" class="h-max min-h-screen">
       <textarea ref="toEl" v-text="to" />
     </Pane>
   </Splitpanes>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

when toggle two columns to one column, the panel got incorrect size

![image](https://github.com/antfu/vite-plugin-inspect/assets/31237954/74dda556-8a0e-472e-9d72-880fa6b8130a)

fix eslint: do not use new Array

![Snipaste_2023-07-13_23-39-26](https://github.com/antfu/vite-plugin-inspect/assets/31237954/5a97dd3f-d1f6-4de9-8595-4e2f5319b9ff)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
