### PR TITLE
feat: use vite logger

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -185,7 +185,7 @@ export default function PluginInspect(options: Options = {}): Plugin {
           host = `${u.protocol}//${u.host}`
         }
         catch (error) {
-          console.warn('Parse resolved url failed:', error)
+          config.logger.warn(`Parse resolved url failed: ${error}`)
         }
       }
 
@@ -193,8 +193,8 @@ export default function PluginInspect(options: Options = {}): Plugin {
 
       if (!silent) {
         const colorUrl = (url: string) => c.green(url.replace(/:(\d+)\//, (_, port) => `:${c.bold(port)}/`))
-        // eslint-disable-next-line no-console
-        console.log(`  ${c.green('➜')}  ${c.bold('Inspect')}: ${colorUrl(`${host}${base}__inspect/`)}`)
+
+        config.logger.info(`  ${c.green('➜')}  ${c.bold('Inspect')}: ${colorUrl(`${host}${base}__inspect/`)}`)
       }
 
       if (_open && !isCI) {
@@ -275,8 +275,8 @@ export default function PluginInspect(options: Options = {}): Plugin {
       if (!build)
         return
       const dir = await generateBuild(ctx, config)
-      // eslint-disable-next-line no-console
-      console.log(c.green('Inspect report generated at'), c.dim(`${dir}`))
+
+      config.logger.info(`${c.green('Inspect report generated at')}  ${c.dim(`${dir}`)}`)
       if (_open && !isCI)
         createPreviewServer(dir)
     },


### PR DESCRIPTION
### Description

This PR removes `console.log` calls and changes logging to use the logger from the resolved Vite config. This way it applies all Vite logger customizations that the developer or framework using Vite did.

### Linked Issues

https://github.com/lazarv/react-server/issues/10

### Additional context

The `@lazarv/react-server` React meta-framework has a custom logger in place in the Vite configuration and it looks off when `vite-plugin-inspect` is just using `console.log` when printing it's own URLs. Timestamp and prefix configured for the custom logger was not used by this plugin before the changes this PR introduces.