### PR TITLE
fix: original error masked when missing stack

### DIFF
--- a/src/node/hijack.ts
+++ b/src/node/hijack.ts
@@ -175,7 +175,7 @@ export function hijackPlugin(
 }
 
 function parseError(error: any): ParsedError {
-  const stack = parseErrorStacks(error)
+  const stack = error.stack ? parseErrorStacks(error) : []
   const message = error.message || String(error)
   return {
     message,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR using internal fix, we can provide options if this another PR merged https://github.com/antfu/error-stack-parser-es/pull/1

### Linked Issues
closes #115

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
With this PR, the reproduction in linked issue:

![imagen](https://github.com/user-attachments/assets/aaeeb980-fa3a-40a7-9a38-35c60cfec5c0)

