### PR TITLE
fix: to #126

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "simple-git-hooks": "^2.11.1",
     "splitpanes": "^3.1.5",
     "typescript": "~5.7.2",
-    "unbuild": "^3.0.1",
+    "unbuild": "^2.0.0",
     "unocss": "^0.65.2",
     "unplugin-auto-import": "^0.19.0",
     "unplugin-vue-components": "^0.28.0",


### PR DESCRIPTION
Because of this #48d4 commit, update some dependencies;

By performing a binary exclusion of the package files, I identified that the issue is caused by the `unbuild` library.
