### PR TITLE
build: create entry for `dirs` to stabilize path resolve

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -4,6 +4,7 @@ export default defineBuildConfig({
   entries: [
     'src/index',
     'src/nuxt',
+    'src/dirs',
   ],
   clean: false,
   declaration: true,
@@ -29,13 +30,13 @@ export default defineBuildConfig({
       ] = await Promise.all([
         import('node:module').then(m => m.default || m),
         import ('node:fs/promises').then(m => m.lstat),
-        import('./dist/index.mjs').then(m => m.DIR_CLIENT),
+        import('./dist/dirs.mjs').then(m => m.DIR_CLIENT),
       ])
       let stats = await lstat(esmDirClient)
       if (!stats.isDirectory()) {
         throw new Error('ESM: Client directory does not exist, review src/dirs.ts module!')
       }
-      const cjsDirClient = createRequire(import.meta.url)('./dist/index.cjs').DIR_CLIENT
+      const cjsDirClient = createRequire(import.meta.url)('./dist/dirs.cjs').DIR_CLIENT
       stats = await lstat(cjsDirClient)
       if (!stats.isDirectory()) {
         throw new Error('CJS: Client directory does not exist, review src/dirs.ts module!')

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -12,3 +12,4 @@ function patchCjs(cjsModulePath: string, name: string) {
 }
 
 patchCjs(resolve('./dist/nuxt.cjs'), 'nuxt')
+patchCjs(resolve('./dist/index.cjs'), 'index.PluginInspect')

--- a/src/dirs.ts
+++ b/src/dirs.ts
@@ -5,4 +5,4 @@ export const DIR_DIST = typeof __dirname !== 'undefined'
   ? __dirname
   : dirname(fileURLToPath(import.meta.url))
 
-export const DIR_CLIENT = resolve(DIR_DIST, '../../dist/client')
+export const DIR_CLIENT = resolve(DIR_DIST, '../dist/client')

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -4,7 +4,7 @@ import { isAbsolute, join, resolve } from 'node:path'
 import process from 'node:process'
 import fs from 'fs-extra'
 import { hash } from 'ohash'
-import { DIR_CLIENT } from '../dir'
+import { DIR_CLIENT } from '../dirs'
 
 export async function generateBuild(
   ctx: InspectContext,

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -7,7 +7,7 @@ import { debounce } from 'perfect-debounce'
 import c from 'picocolors'
 import sirv from 'sirv'
 import { createRPCServer } from 'vite-dev-rpc'
-import { DIR_CLIENT } from '../dir'
+import { DIR_CLIENT } from '../dirs'
 import { generateBuild } from './build'
 import { InspectContext } from './context'
 import { hijackPlugin } from './hijack'
@@ -16,8 +16,6 @@ import { createServerRpc } from './rpc'
 import { openBrowser } from './utils'
 
 export * from './options'
-
-export { DIR_CLIENT }
 
 const NAME = 'vite-plugin-inspect'
 const isCI = !!process.env.CI


### PR DESCRIPTION
This to make sure the logic in `dirs.ts` always be bundled as `dist/dirs.ts`