### PR TITLE
fix: diff positioning with CRLF

### DIFF
--- a/src/client/worker/diff.worker.ts
+++ b/src/client/worker/diff.worker.ts
@@ -2,7 +2,7 @@ import { expose } from 'comlink'
 import { diffCleanupSemantic, diffMain } from 'diff-match-patch-es'
 
 function calculateDiff(left: string, right: string) {
-  const changes = diffMain(left, right)
+  const changes = diffMain(left.replace(/\r\n/g, '\n'), right.replace(/\r\n/g, '\n'))
   diffCleanupSemantic(changes)
   return changes
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently the diff breaks when one side has CRLF and the other side LF line endings. This PR adds a small replace to the diff worker to fix the positioning.

Before:
![image](https://github.com/user-attachments/assets/95c79c62-4c29-4c83-b765-7405379fde6f)

After:
![image](https://github.com/user-attachments/assets/2c4301b1-8c58-4b7c-83e8-ce2e956822e7)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

A different approach would be to set the CodeMirror instances to the correct line endings, but then there is the problem that each line ending is marked as a change in diff.
If in the future more stuff is added to the code editor this could be reconsidered, but for now only replacing when the diff is requested seems fine to me.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
