### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
     }
   },
   "dependencies": {
+    "ansis": "^3.12.0",
     "debug": "^4.4.0",
     "error-stack-parser-es": "^1.0.5",
     "open": "^10.1.0",
-    "picocolors": "^1.1.1",
     "sirv": "^3.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      ansis:
+        specifier: ^3.12.0
+        version: 3.12.0
       debug:
         specifier: ^4.4.0
         version: 4.4.0
@@ -20,9 +23,6 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.1.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       sirv:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1316,6 +1316,10 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  ansis@3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -5315,6 +5319,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@6.2.1: {}
+
+  ansis@3.12.0: {}
 
   any-promise@1.3.0: {}
 

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -3,8 +3,8 @@ import type { HMRData, RpcFunctions } from '../types'
 import type { InspectContextVite } from './context'
 import type { ViteInspectOptions } from './options'
 import process from 'node:process'
+import c from 'ansis'
 import { debounce } from 'perfect-debounce'
-import c from 'picocolors'
 import sirv from 'sirv'
 import { createRPCServer } from 'vite-dev-rpc'
 import { DIR_CLIENT } from '../dirs'
@@ -246,7 +246,7 @@ export default function PluginInspect(options: ViteInspectOptions = {}): Plugin 
         return
       const dir = await generateBuild(ctx)
 
-      this.environment!.logger.info(`${c.green('Inspect report generated at')}  ${c.dim(`${dir}`)}`)
+      this.environment!.logger.info(`${c.green('Inspect report generated at')}  ${c.dim(dir)}`)
       if (_open && !isCI)
         createPreviewServer(dir)
     },

--- a/src/node/preview.ts
+++ b/src/node/preview.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net'
 import { createServer } from 'node:http'
-import c from 'picocolors'
+import c from 'ansis'
 import sirv from 'sirv'
 import { openBrowser } from './utils'
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).