### PR TITLE
fix: rm `outputDir` with `force` option to ignore ENOENT exception

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -29,7 +29,7 @@ export default defineBuildConfig({
         esmDirClient,
       ] = await Promise.all([
         import('node:module').then(m => m.default || m),
-        import ('node:fs/promises').then(m => m.lstat),
+        import('node:fs/promises').then(m => m.lstat),
         import('./dist/dirs.mjs').then(m => m.DIR_CLIENT),
       ])
       let stats = await lstat(esmDirClient)

--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -19,7 +19,7 @@ export async function generateBuild(
     : resolve(process.cwd(), outputDir)
   const reportsDir = join(targetDir, 'reports')
 
-  await fs.rm(targetDir, { recursive: true })
+  await fs.rm(targetDir, { recursive: true, force: true })
   await fs.mkdir(reportsDir, { recursive: true })
   await fs.cp(DIR_CLIENT, targetDir, { recursive: true })
 
@@ -71,5 +71,5 @@ export async function generateBuild(
 }
 
 function writeJSON(filename: string, data: any) {
-  return fs.writeFile(filename, JSON.stringify(data, null, 2) + '\n')
+  return fs.writeFile(filename, `${JSON.stringify(data, null, 2)}\n`)
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- Added `force` option for `fs.rm` call to ignore `ENOENT` exception.
- Lint issue for extra space.
- Lint issue for string concat.

### Linked Issues

#141 

### Additional context

- https://nodejs.org/api/fs.html#fspromisesrmpath-options
