### PR TITLE
fix(cjs): wrong cjs default exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-inspect",
   "type": "module",
   "version": "10.2.1",
-  "packageManager": "pnpm@10.3.0",
+  "packageManager": "pnpm@10.4.0",
   "description": "Inspect the intermediate state of Vite plugins",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "license": "MIT",

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -1,18 +1,112 @@
-import { readFileSync, writeFileSync } from 'node:fs'
-import fsp from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { readFile, writeFile } from 'node:fs/promises'
+// import { readFileSync, writeFileSync } from 'node:fs'
+import { findExports, findStaticImports, parseStaticImport } from 'mlly'
 
-function patchCjs(cjsModulePath: string, name: string) {
-  const cjsModule = readFileSync(cjsModulePath, 'utf-8')
-  writeFileSync(
-    cjsModulePath,
-    cjsModule
-      .replace(`module.exports = ${name};`, `exports = ${name};`),
-    { encoding: 'utf-8' },
+const regexp = /export\s*\{([^}]*)\}/
+const defaultExportRegexp = /\s*as\s+default\s*/
+const typeExportRegexp = /\s*type\s+/
+
+// Temporal fix for unbuild cjs plugin: will work only here.
+// The current unbuild cjs plugin fixing only some default exports in d.cts files.
+// This script will not fix export { default } from '<some-specifier>'.
+async function fixDefaultCJSExports(path: string) {
+  const code = await readFile(path, 'utf-8')
+  console.log(code)
+
+  const defaultExport = findExports(code).find(e =>
+    e.names.includes('default'),
+  )
+
+  if (!defaultExport) {
+    return
+  }
+
+  const match = defaultExport.code.match(regexp)
+  if (!match?.length) {
+    return
+  }
+
+  let defaultAlias: string | undefined
+  const exportsEntries: string[] = []
+  for (const exp of match[1].split(',').map(e => e.trim())) {
+    const m = exp.match(defaultExportRegexp)
+    if (m) {
+      defaultAlias = exp.replace(m[0], '')
+    }
+    else {
+      exportsEntries.push(exp)
+    }
+  }
+
+  if (!defaultAlias) {
+    // handle default export like:
+    // import defaultExport from '<some-identifier>'
+    // export default defaultExport
+    // dts plugin will generate code like:
+    // import defaultExport from '<some-identifier>';
+    // export { default } from '<some-identifier>';
+    const defaultStaticImport = findStaticImports(code).find(i => i.specifier === defaultExport.specifier)
+    const defaultImport = defaultStaticImport ? parseStaticImport(defaultStaticImport).defaultImport : undefined
+    if (!defaultExport) {
+      return
+    }
+    // this will generate the following code:
+    // import defaultExport from '<some-identifier>';
+    // export = defaultExport;
+    await writeFile(
+      path,
+      code.replace(
+        defaultExport.code,
+        `export = ${defaultImport}`,
+      ),
+      'utf-8',
+    )
+    return
+  }
+
+  let exportStatement = exportsEntries.length > 0 ? undefined : ''
+
+  // replace export { type A, type B, type ... } with export type { A, B, ... }
+  // that's, if all remaining exports are type exports, replace export {} with export type {}
+  if (exportStatement === undefined) {
+    const imports = findStaticImports(code).map(i => i.imports)
+    let someExternalExport = false
+    const allRemainingExports = exportsEntries.map((exp) => {
+      if (someExternalExport) {
+        return [exp, ''] as const
+      }
+      if (!imports.includes(exp)) {
+        const m = exp.match(typeExportRegexp)
+        if (m) {
+          const name = exp.replace(m[0], '').trim()
+          if (!imports.includes(name)) {
+            return [exp, name] as const
+          }
+        }
+      }
+      someExternalExport = true
+      return [exp, ''] as const
+    })
+    exportStatement = someExternalExport
+      ? `;\nexport { ${allRemainingExports.map(([e, _]) => e).join(', ')} }`
+      : `;\nexport type { ${allRemainingExports.map(([_, t]) => t).join(', ')} }`
+  }
+
+  await writeFile(
+    path,
+    code.replace(
+      defaultExport.code,
+      `export = ${defaultAlias}${exportStatement}`,
+    ),
+    'utf-8',
   )
 }
 
-patchCjs(resolve('./dist/nuxt.cjs'), 'nuxt')
-patchCjs(resolve('./dist/index.cjs'), 'index.PluginInspect')
+function mapDualPaths(files: string[]) {
+  return files.map(name => [
+    fixDefaultCJSExports(`dist/${name}.d.ts`),
+    fixDefaultCJSExports(`dist/${name}.d.cts`),
+  ])
+}
 
-await fsp.cp('src/client/public/assets/fonts', 'dist/client/assets/fonts', { recursive: true })
+await Promise.all(mapDualPaths(['nuxt', 'index']))

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -11,7 +11,6 @@ const typeExportRegexp = /\s*type\s+/
 // This script will not fix export { default } from '<some-specifier>'.
 async function fixDefaultCJSExports(path: string) {
   const code = await readFile(path, 'utf-8')
-  console.log(code)
 
   const defaultExport = findExports(code).find(e =>
     e.names.includes('default'),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
We're patching `.cjs` files and we must patch `d.ts` and `d.cts` files, there is an extra `default.default` when resolving the inspect plugin in the vite config file (check the screenshot in the linked issue).

I'm going to try to fix it at `unbuild` ASAP, I need to create the repository and publish initial version, I guess this weekend should be fixed 🤞 .

This PR also updates pnpm to `v10.4.0`.

### Linked Issues
closes #143

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
