### PR TITLE
chore(client): Optimize the splitpanes style

### DIFF
--- a/src/client/components/DiffEditor.vue
+++ b/src/client/components/DiffEditor.vue
@@ -143,7 +143,7 @@ function onUpdate(size: number) {
 
 <template>
   <Splitpanes @resize="onUpdate($event[0].size)">
-    <Pane v-show="!oneColumn" min-size="10" :size="leftPanelSize" border="main r">
+    <Pane v-show="!oneColumn" min-size="10" :size="leftPanelSize">
       <div ref="fromEl" class="h-inherit" />
     </Pane>
     <Pane min-size="10" :size="100 - leftPanelSize">

--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -178,7 +178,7 @@ getHot().then((hot) => {
     <Splitpanes h-full of-hidden @resize="options.view.panelSizeModule = $event[0].size">
       <Pane
         :size="options.view.panelSizeModule" min-size="10"
-        flex="~ col" border="r main"
+        flex="~ col"
         overflow-y-auto
       >
         <div flex="~ gap2 items-center" p2 tracking-widest class="op75 dark:op50">

--- a/src/client/styles/main.css
+++ b/src/client/styles/main.css
@@ -20,7 +20,8 @@ html.dark {
   font-size: 13px !important;
 }
 
-.CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+.CodeMirror-scrollbar-filler,
+.CodeMirror-gutter-filler {
   background-color: var(--cm-background) !important;
 }
 
@@ -37,8 +38,14 @@ html.dark {
   transition: none !important;
 }
 
+.splitpanes__pane[style*="display: none"]+.splitpanes__splitter,
+.splitpanes__pane[hidden]+.splitpanes__splitter {
+  display: none;
+}
+
 .splitpanes__splitter {
   position: relative;
+  @apply bg-gray:30
 }
 
 .splitpanes__splitter:before {
@@ -57,22 +64,22 @@ html.dark {
 }
 
 .splitpanes--vertical>.splitpanes__splitter {
-  width: 0 !important;
+  width: 1px !important;
 }
 
 .splitpanes--horizontal>.splitpanes__splitter {
-  height: 0 !important;
+  height: 1px !important;
 }
 
 .splitpanes--vertical>.splitpanes__splitter:before {
   left: -5px;
-  right: -4px;
+  right: -5px;
   height: 100%;
 }
 
 .splitpanes--horizontal>.splitpanes__splitter:before {
   top: -5px;
-  bottom: -4px;
+  bottom: -5px;
   width: 100%;
 }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<img width="1633" alt="image" src="https://github.com/user-attachments/assets/ba0a248d-d2d1-4495-a508-9fc608fb6faa" />
<img width="1584" alt="image" src="https://github.com/user-attachments/assets/594a44ba-cb40-4ea4-818c-6fb4f385d3e6" />


When the state is oneColumn, the splitpanes__splitter is not hidden.
The default min-width of splitpanes__splitter is 1px, so it cannot be set to 0.
Use splitpanes__splitter as a border to optimize the style.

