### PR TITLE
fix: use `this.environment` in `hotUpdate` for Vite 7 compatibility

### DIFF
--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -252,9 +252,9 @@ export default function PluginInspect(options: ViteInspectOptions = {}): Plugin 
         return null
       },
     },
-    hotUpdate({ modules, environment }) {
+    hotUpdate({ modules }) {
       const ids = modules.map(module => module.id)
-      environment.hot.send({
+      this.environment.hot.send({
         type: 'custom',
         event: 'vite-plugin-inspect:update',
         data: { ids } as HMRData,


### PR DESCRIPTION
### Description

I was testing my own plugin with Vite 7 beta override (https://github.com/hi-ogawa/vite-plugins/pull/944) and noticed `vite-plugin-inspect`'s `hotUpdate` is causing an error, which was used in one of my test case.

```
Cannot read properties of undefined (reading 'hot')
    at MinimalPluginContext.hotUpdate (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/vite-plugin-inspect@11.0.1_vite@7.0.0-beta.1_@types+node@22.14.1_jiti@2.4.2_lightningcs_b960494e74fe6a7fc89f3caa40fce88e/node_modules/vite-plugin-inspect/dist/shared/vite-plugin-inspect.Bht9Q8w0.mjs:681:19)
```

`hotUpdate({ environment })` is deprecated all along during Vite 6 and `hotUpdate() { this.environment }` has been a stable alternative. See https://github.com/vitejs/vite/pull/19986 for the detail.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
