### PR TITLE
fix: generate metadata for all environments for build

### DIFF
--- a/src/node/build.ts
+++ b/src/node/build.ts
@@ -64,10 +64,6 @@ export function createBuildGenerator(ctx: InspectContext) {
               'data-vite-inspect-mode="BUILD"',
             ),
         ),
-        writeJSON(
-          join(reportsDir, 'metadata.json'),
-          ctx.getMetadata(),
-        ),
       ])
     },
     async generateForEnv(pluginCtx: Rollup.PluginContext) {
@@ -101,6 +97,12 @@ export function createBuildGenerator(ctx: InspectContext) {
               )),
           ])
         }),
+      )
+    },
+    async generateMetadata() {
+      await writeJSON(
+        join(reportsDir, 'metadata.json'),
+        ctx.getMetadata(),
       )
     },
   }

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -223,6 +223,8 @@ export default function PluginInspect(options: ViteInspectOptions = {}): Plugin 
             await buildGenerator.generateForEnv(pluginCtx)
           },
           async onLast(pluginCtx) {
+            await buildGenerator.generateMetadata()
+
             const dir = buildGenerator.getOutputDir()
             pluginCtx.environment.logger.info(`${c.green('Inspect report generated at')}  ${c.dim(dir)}`)
             if (_open && !isCI)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

At build time, each environment has its own config (unless `builder.sharedConfigBuild: true` is used), so they are treated as multiple Vite instances (this is the behavior of #148 when it's working). 

However, #148 writes `reports/metadata.json` after the first environment finishes building. In small projects, the second environment might be able to start building and register itself to `InspectContext`, while this plugin prepares its output folder and copies frontend files, to be included in the `reports/metadata.json` file.

But for larger projects, there are many works to do after the `buildEnd` Vite plugin hook, like writing bundled files to output folder, or other plugin hooks, so the second environment can't start in time.

This PR delays writing metadata file after all environments finish building.

| Before | After |
|----| ----|
| ![image](https://github.com/user-attachments/assets/c22d1586-865b-4516-af89-d05648a987fb) | ![image](https://github.com/user-attachments/assets/57e710c2-7b32-4101-a4a3-491fe79aa33c) |

### Linked Issues

Fixes #153

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

As mentioned above, multiple environments each have their own config object, so It would require significate changes to treat multiple environments as same Vite instance (likely we need a virtual Vite instance concept, and register that in the `buildApp` hook), which this PR doesn't do.