### PR TITLE
fix: error fetching panel size during resize event

### DIFF
--- a/src/client/components/DiffEditor.vue
+++ b/src/client/components/DiffEditor.vue
@@ -142,7 +142,7 @@ function onUpdate(size: number) {
 </script>
 
 <template>
-  <Splitpanes @resize="onUpdate($event[0].size)">
+  <Splitpanes @resize="onUpdate($event.prevPane.size)">
     <Pane v-show="!oneColumn" min-size="10" :size="leftPanelSize">
       <div ref="fromEl" class="h-inherit" />
     </Pane>

--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -175,7 +175,7 @@ getHot().then((hot) => {
     v-else-if="info && filteredTransforms"
     flex overflow-hidden
   >
-    <Splitpanes h-full of-hidden @resize="options.view.panelSizeModule = $event[0].size">
+    <Splitpanes h-full of-hidden @resize="options.view.panelSizeModule = $event.prevPane.size">
       <Pane
         :size="options.view.panelSizeModule" min-size="10"
         flex="~ col"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I found an error when adjusting the diff editor panel size. In this PR, I checked the Splitpanes documentation and fixed this issue.

<img width="972" height="308" alt="CleanShot 2025-07-25 at 14 51 20@2x" src="https://github.com/user-attachments/assets/d3311826-9bbf-4217-b957-7addabf73375" />

### Linked Issues

null

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

null
