### PR TITLE
fix(module): removed `key` in diff editor

### DIFF
--- a/src/client/pages/index/module.vue
+++ b/src/client/pages/index/module.vue
@@ -245,7 +245,6 @@ getHot().then((hot) => {
           />
           <DiffEditor
             v-else
-            :key="id"
             :one-column="options.view.showOneColumn || !!currentTransform?.error"
             :diff="options.view.diff && !currentTransform?.error"
             :from="from" :to="to"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

#### Problem

The diff editor isn't able to display the code after we navigate to other page and navigate back

After some testing, the `key` on `DiffEditor` caused this bug, I guess the status in the components may not completely reset, and the same key let it reuses components

### Linked Issues

N/A

### Additional context

The video of the issue and the fix

https://github.com/user-attachments/assets/b81ce7f1-8271-437e-bcfa-682d9a752547


