### PR TITLE
fix: remove unexpected scrollbar on the narrow screen

### DIFF
--- a/src/client/App.vue
+++ b/src/client/App.vue
@@ -12,7 +12,7 @@ await payload.init()
 </script>
 
 <template>
-  <main grid="~ rows-[min-content_1fr]" size="h-screen w-screen">
+  <main grid="~ rows-[min-content_1fr]" size="h-full w-screen">
     <Suspense>
       <RouterView />
       <template #fallback>

--- a/src/client/components/Container.vue
+++ b/src/client/components/Container.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-[calc(100vh-55px)]">
+  <div class="h-full">
     <slot />
   </div>
 </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The `main` box and `Container` component are using `h-screen` to calculate the height of page, but `h-screen` will includes the horizontal scrollbar, so the unexpected vertical scrollbar will be also displayed if the screen is narrow, and `h-full` is not including the scrollbar, so it can fix it. 

### Linked Issues

N/A

### Additional context

#### Before
<img width="653" height="911" alt="Before" src="https://github.com/user-attachments/assets/09fc9a5b-fcaf-473e-881e-d285d6065575" />

#### After
<img width="747" height="914" alt="After" src="https://github.com/user-attachments/assets/ba5b7da5-a464-4ccb-951a-1dc395519ea6" />

