### PR TITLE
fix(client): don't include `vite:devtools:injection` plugin at build time

### DIFF
--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ESNext", "DOM"],
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "strict": true,
     "sourceMap": true,

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -1,4 +1,6 @@
+import type { Plugin } from 'vite'
 import { join, resolve } from 'node:path'
+import process from 'node:process'
 import { DevTools } from '@vitejs/devtools'
 import Vue from '@vitejs/plugin-vue'
 import Unocss from 'unocss/vite'
@@ -8,6 +10,33 @@ import { defineConfig } from 'vite'
 import { VueRouterAutoImports } from 'vue-router/unplugin'
 import VueRouter from 'vue-router/vite'
 import Inspect from '../node'
+
+const plugins: () => Promise<Plugin[]> = process.env.VITE_DEVTOOLS_LOCAL_DEV
+  ? DevTools
+  : async () => {
+    const devtools = await DevTools()
+
+    const devtoolsPlugin = devtools.filter(p => p.name !== 'vite:devtools:injection')
+    return [
+      ...devtoolsPlugin,
+      <Plugin>{
+        name: 'devtools:plugin:injector',
+        enforce: 'post',
+        apply: 'build',
+        transformIndexHtml() {
+          return [{
+            tag: 'script',
+            attrs: {
+              id: 'vite-plugin-inspect-devtools-injector',
+              src: 'vite-plugin-inspect-devtools-injector.js',
+              type: 'module',
+            },
+            injectTo: 'body',
+          }]
+        },
+      },
+    ]
+  }
 
 export default defineConfig({
   base: './',
@@ -19,7 +48,7 @@ export default defineConfig({
   },
 
   plugins: [
-    DevTools(),
+    plugins(),
     {
       name: 'local:object-hook-transform',
       transform: {

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -27,7 +27,6 @@ const plugins: () => Promise<Plugin[]> = process.env.VITE_DEVTOOLS_LOCAL_DEV
           return [{
             tag: 'script',
             attrs: {
-              id: 'vite-plugin-inspect-devtools-injector',
               src: 'vite-plugin-inspect-devtools-injector.js',
               type: 'module',
             },

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -117,13 +117,19 @@ export default function PluginInspect(options: ViteInspectOptions = {}): Plugin 
       res.end()
     })
 
-    const resolvedPathPromise = getPackageInfo('@vitejs/devtools').then((pkg) => {
-      return readFile(resolve(pkg!.rootPath, 'dist/client/inject.js'), 'utf8')
+    const clientEntryPointPromise = getPackageInfo('@vitejs/devtools').then(async (pkg) => {
+      const clientFile = await readFile(resolve(DIR_CLIENT, 'index.html'), { encoding: 'utf8' })
+      return clientFile.replace('vite-plugin-inspect-devtools-injector.js', `/@fs/${resolve(pkg!.rootPath, 'dist/client/inject.js').replace(/\\/g, '/')}`)
     })
 
-    server.middlewares.use(`${base}.vite-inspect/vite-plugin-inspect-devtools-injector.js`, async (_, res) => {
-      res.writeHead(200, { 'content-type': 'application/javascript; charset=utf-8' })
-      return res.end(await resolvedPathPromise)
+    server.middlewares.use(`${base}.vite-inspect`, async (req, res, next) => {
+      const url = req.url
+      if (url === '' || url === '/') {
+        res.writeHead(200, { 'content-type': 'text/html' })
+        return res.end(await clientEntryPointPromise)
+      }
+
+      next()
     })
 
     server.middlewares.use(`${base}.vite-inspect`, sirv(DIR_CLIENT, {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -2,7 +2,10 @@ import type { Connect, Plugin, Rollup, ViteDevServer } from 'vite'
 import type { HMRData } from '../types'
 import type { InspectContextVite } from './context'
 import type { ViteInspectOptions } from './options'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import c from 'ansis'
+import { getPackageInfo } from 'local-pkg'
 import { debounce } from 'perfect-debounce'
 import sirv from 'sirv'
 import { DIR_CLIENT } from '../dirs'
@@ -112,6 +115,15 @@ export default function PluginInspect(options: ViteInspectOptions = {}): Plugin 
       const newUrl = req.url?.replace(/^\/?/, `${base}.vite-inspect/`) ?? `${base}.vite-inspect/`
       res.writeHead(302, { Location: newUrl })
       res.end()
+    })
+
+    const resolvedPathPromise = getPackageInfo('@vitejs/devtools').then((pkg) => {
+      return readFile(resolve(pkg!.rootPath, 'dist/client/inject.js'), 'utf8')
+    })
+
+    server.middlewares.use(`${base}.vite-inspect/vite-plugin-inspect-devtools-injector.js`, async (_, res) => {
+      res.writeHead(200, { 'content-type': 'application/javascript; charset=utf-8' })
+      return res.end(await resolvedPathPromise)
     })
 
     server.middlewares.use(`${base}.vite-inspect`, sirv(DIR_CLIENT, {

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -119,7 +119,10 @@ export default function PluginInspect(options: ViteInspectOptions = {}): Plugin 
 
     const clientEntryPointPromise = getPackageInfo('@vitejs/devtools').then(async (pkg) => {
       const clientFile = await readFile(resolve(DIR_CLIENT, 'index.html'), { encoding: 'utf8' })
-      return clientFile.replace('vite-plugin-inspect-devtools-injector.js', `/@fs/${resolve(pkg!.rootPath, 'dist/client/inject.js').replace(/\\/g, '/')}`)
+      return clientFile.replace(
+        'vite-plugin-inspect-devtools-injector.js',
+        `/@fs/${resolve(pkg!.rootPath, 'dist/client/inject.js').replace(/\\/g, '/')}`,
+      )
     })
 
     server.middlewares.use(`${base}.vite-inspect`, async (req, res, next) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

When building the client, we use vite devtools plugin and this is wrong, since it will add the module at client/index.html using local dist inject path: `/@fs//home/<some-path>/.node_modules/<some-path>/@vitejs/devtools/dist/client/inject.js`.

This PR includes:
- removes `vite:devtools:injection` from `@vitejs/devtools` plugin (from vite config file at client), current `client/index.html` at npm registry contains this: `<script src="/@fs//home/runner/work/vite-plugin-inspect/vite-plugin-inspect/node_modules/.pnpm/@vitejs+devtools@0.1.11_@pnpm+logger@1001.0.1_typescript@5.9.3_vite@8.0.2/node_modules/@vitejs/devtools/dist/client/inject.js" type="module"></script>`
- adds a new Vite plugin at client to write a module we can hack later at node:  `<script src="vite-plugin-inspect-devtools-injector.js" type="module"></script>`
- adds a new middleware to replace `vite-plugin-inspect-devtools-injector.js` at client entry point: now the middleware just loads the client entry point and replaces `vite-plugin-inspect-devtools-injector.js` with the original `/@vitejs/devtools/dist/client/inject.js` but using consumer path

This PR also includes a change at playground tsconfig.json file to use `bundler` instead `node` module resolution: Vite 8 has removed node10 types.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

### Linked Issues

fixes #169

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
