### PR TITLE
feat(client): highlight circular dependencies in module graph

### DIFF
--- a/playground/src/circular-a.ts
+++ b/playground/src/circular-a.ts
@@ -1,4 +1,5 @@
 // Example circular dependency for testing graph highlighting
 import './circular-b'
+import './circular-c'
 
 export const a = 'circular-a'

--- a/playground/src/circular-a.ts
+++ b/playground/src/circular-a.ts
@@ -1,0 +1,4 @@
+// Example circular dependency for testing graph highlighting
+import './circular-b'
+
+export const a = 'circular-a'

--- a/playground/src/circular-b.ts
+++ b/playground/src/circular-b.ts
@@ -1,0 +1,4 @@
+// Example circular dependency for testing graph highlighting
+import './circular-a'
+
+export const b = 'circular-b'

--- a/playground/src/circular-b.ts
+++ b/playground/src/circular-b.ts
@@ -1,4 +1,5 @@
 // Example circular dependency for testing graph highlighting
 import './circular-a'
+import './circular-c'
 
 export const b = 'circular-b'

--- a/playground/src/circular-c.ts
+++ b/playground/src/circular-c.ts
@@ -1,0 +1,5 @@
+// Example circular dependency for testing graph highlighting
+export { a } from './circular-a'
+export { b } from './circular-b'
+
+export const c = 'circular-c'

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import './style.css'
+import './circular-a'
 
 const app = createApp(App)
 app.use(router)

--- a/src/client/components/Graph.vue
+++ b/src/client/components/Graph.vue
@@ -3,6 +3,7 @@ import type { Data, Options } from 'vis-network'
 import type { ModuleInfo } from '../../types'
 import { DataSet } from 'vis-data'
 import { Network } from 'vis-network'
+import { detectCircularDeps, edgeKey } from '../logic/circular'
 import { useOptionsStore } from '../stores/options'
 import { useSearchResults } from '../stores/search'
 
@@ -48,11 +49,17 @@ const shapes = [
 ]
 const router = useRouter()
 
+const circularResult = computed(() => detectCircularDeps(search.filtered))
+
 const data = computed(() => {
   const modules = search.filtered
+  const circular = circularResult.value
+  const highlight = options.view.graphHighlightCircular
+
   const nodes = new DataSet(modules.map((mod) => {
     const path = mod.id.replace(/\?.*$/, '').replace(/#.*$/, '')
     const group = path.match(/\.(\w+)$/)?.[1] || 'unknown'
+    const isCircular = highlight && circular.nodes.has(mod.id)
     return {
       id: mod.id,
       label: path.split('/').splice(-1)[0],
@@ -64,21 +71,28 @@ const data = computed(() => {
         : mod.virtual
           ? 'diamond'
           : 'dot',
+      borderWidth: isCircular ? 3 : 0,
+      color: isCircular ? { border: '#e84545' } : undefined,
     }
   }))
-  const edges: Data['edges'] = modules.flatMap(mod => mod.deps.map(dep => ({
-    from: mod.id,
-    to: dep,
-    arrows: {
-      to: {
-        enabled: true,
-        scaleFactor: 0.8,
+  const edges: Data['edges'] = modules.flatMap(mod => mod.deps.map((dep) => {
+    const isCircular = highlight && circular.edges.has(edgeKey(mod.id, dep))
+    return {
+      from: mod.id,
+      to: dep,
+      arrows: {
+        to: {
+          enabled: true,
+          scaleFactor: 0.8,
+        },
       },
-    },
-    color: {
-      opacity: 0.8,
-    },
-  })))
+      color: isCircular
+        ? { color: '#e84545', opacity: 1, highlight: '#e84545' }
+        : { opacity: 0.8 },
+      width: isCircular ? 2.5 : 1,
+      dashes: isCircular ? [8, 4] : false,
+    }
+  }))
 
   return {
     nodes,
@@ -173,6 +187,20 @@ onMounted(() => {
           {{ shape.type }}
         </div>
       </div>
+      <div border="t base" my3 h-1px />
+      <label flex="~ gap-2 items-center" cursor-pointer>
+        <input
+          v-model="options.view.graphHighlightCircular"
+          type="checkbox"
+        >
+        <div h-3 w-5 border="~ [#e84545] 2 dashed" rounded-sm />
+        <div>
+          circular
+          <span v-if="circularResult.cycles.length" op50>
+            ({{ circularResult.cycles.length }})
+          </span>
+        </div>
+      </label>
     </div>
     <div
       border="~ main"

--- a/src/client/logic/circular.ts
+++ b/src/client/logic/circular.ts
@@ -1,0 +1,83 @@
+import type { ModuleInfo } from '../../types'
+
+export interface CircularEdge {
+  from: string
+  to: string
+}
+
+export interface CircularResult {
+  /** 所有参与循环依赖的模块 ID */
+  nodes: Set<string>
+  /** 所有构成循环的边 (from -> to) */
+  edges: Set<string> // 格式: `${from}\0${to}`
+  /** 每个独立的环 (用于 tooltip 等展示) */
+  cycles: string[][]
+}
+
+/**
+ * 检测模块依赖图中的所有循环依赖
+ * 使用 DFS + 路径回溯，收集所有环上的节点和边
+ */
+export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResult {
+  const adj = new Map<string, string[]>()
+  const idSet = new Set<string>()
+
+  for (const mod of modules) {
+    idSet.add(mod.id)
+    adj.set(mod.id, mod.deps.filter(d => idSet.has(d) || modules.some(m => m.id === d)))
+  }
+
+  // 优化：建完整邻接表后再过滤
+  for (const mod of modules) {
+    adj.set(mod.id, mod.deps.filter(d => adj.has(d)))
+  }
+
+  const circularNodes = new Set<string>()
+  const circularEdges = new Set<string>()
+  const cycles: string[][] = []
+
+  // 0=未访问, 1=栈中, 2=已完成
+  const state = new Map<string, number>()
+  const path: string[] = []
+
+  function dfs(node: string) {
+    state.set(node, 1)
+    path.push(node)
+
+    for (const dep of adj.get(node) || []) {
+      const depState = state.get(dep) ?? 0
+      if (depState === 1) {
+        // 发现环！从 path 中找到环的起点
+        const cycleStart = path.indexOf(dep)
+        if (cycleStart !== -1) {
+          const cycle = path.slice(cycleStart)
+          cycles.push([...cycle])
+          // 标记环上所有节点和边
+          for (let i = 0; i < cycle.length; i++) {
+            circularNodes.add(cycle[i])
+            const next = cycle[(i + 1) % cycle.length]
+            circularEdges.add(`${cycle[i]}\0${next}`)
+          }
+        }
+      }
+      else if (depState === 0) {
+        dfs(dep)
+      }
+    }
+
+    path.pop()
+    state.set(node, 2)
+  }
+
+  for (const mod of modules) {
+    if ((state.get(mod.id) ?? 0) === 0)
+      dfs(mod.id)
+  }
+
+  return { nodes: circularNodes, edges: circularEdges, cycles }
+}
+
+/** 辅助：生成 edge key */
+export function edgeKey(from: string, to: string): string {
+  return `${from}\0${to}`
+}

--- a/src/client/logic/circular.ts
+++ b/src/client/logic/circular.ts
@@ -6,18 +6,14 @@ export interface CircularEdge {
 }
 
 export interface CircularResult {
-  /** 所有参与循环依赖的模块 ID */
+  /** All module IDs that participate in circular dependencies */
   nodes: Set<string>
-  /** 所有构成循环的边 (from -> to) */
-  edges: Set<string> // 格式: `${from}\0${to}`
-  /** 每个独立的环 (用于 tooltip 等展示) */
+  edges: Set<string> //  All edges that form circular dependencies, keyed as `${from}\0${to}`
+  /** Each individual cycle as an array of module IDs */
   cycles: string[][]
 }
 
-/**
- * 检测模块依赖图中的所有循环依赖
- * 使用 DFS + 路径回溯，收集所有环上的节点和边
- */
+/** Detect all circular dependencies in the module dependency graph.\n * Uses DFS with path tracking to collect all cycles. */
 export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResult {
   const adj = new Map<string, string[]>()
   const idSet = new Set<string>()
@@ -27,7 +23,6 @@ export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResu
     adj.set(mod.id, mod.deps.filter(d => idSet.has(d) || modules.some(m => m.id === d)))
   }
 
-  // 优化：建完整邻接表后再过滤
   for (const mod of modules) {
     adj.set(mod.id, mod.deps.filter(d => adj.has(d)))
   }
@@ -36,7 +31,7 @@ export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResu
   const circularEdges = new Set<string>()
   const cycles: string[][] = []
 
-  // 0=未访问, 1=栈中, 2=已完成
+  // 0 = unvisited, 1 = in stack, 2 = done
   const state = new Map<string, number>()
   const path: string[] = []
 
@@ -47,12 +42,11 @@ export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResu
     for (const dep of adj.get(node) || []) {
       const depState = state.get(dep) ?? 0
       if (depState === 1) {
-        // 发现环！从 path 中找到环的起点
+        // Found a cycle — extract it from the path
         const cycleStart = path.indexOf(dep)
         if (cycleStart !== -1) {
           const cycle = path.slice(cycleStart)
           cycles.push([...cycle])
-          // 标记环上所有节点和边
           for (let i = 0; i < cycle.length; i++) {
             circularNodes.add(cycle[i])
             const next = cycle[(i + 1) % cycle.length]
@@ -77,7 +71,6 @@ export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResu
   return { nodes: circularNodes, edges: circularEdges, cycles }
 }
 
-/** 辅助：生成 edge key */
 export function edgeKey(from: string, to: string): string {
   return `${from}\0${to}`
 }

--- a/src/client/logic/circular.ts
+++ b/src/client/logic/circular.ts
@@ -1,61 +1,41 @@
 import type { ModuleInfo } from '../../types'
 
-export interface CircularEdge {
-  from: string
-  to: string
-}
-
 export interface CircularResult {
   /** All module IDs that participate in circular dependencies */
   nodes: Set<string>
-  edges: Set<string> //  All edges that form circular dependencies, keyed as `${from}\0${to}`
+  /** All edges that form circular dependencies, keyed as `${from}\0${to}` */
+  edges: Set<string>
   /** Each individual cycle as an array of module IDs */
   cycles: string[][]
 }
 
-/** Detect all circular dependencies in the module dependency graph.\n * Uses DFS with path tracking to collect all cycles. */
-export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResult {
+/**
+ * Yield each cycle found in the module dependency graph.
+ * Uses DFS with path tracking. Cancellable — consumer can break early.
+ */
+export function* findCircularDeps(modules: readonly ModuleInfo[]): Generator<string[]> {
+  const idSet = new Set(modules.map(m => m.id))
   const adj = new Map<string, string[]>()
-  const idSet = new Set<string>()
-
-  for (const mod of modules) {
-    idSet.add(mod.id)
-    adj.set(mod.id, mod.deps.filter(d => idSet.has(d) || modules.some(m => m.id === d)))
-  }
-
-  for (const mod of modules) {
-    adj.set(mod.id, mod.deps.filter(d => adj.has(d)))
-  }
-
-  const circularNodes = new Set<string>()
-  const circularEdges = new Set<string>()
-  const cycles: string[][] = []
+  for (const mod of modules)
+    adj.set(mod.id, mod.deps.filter(d => idSet.has(d)))
 
   // 0 = unvisited, 1 = in stack, 2 = done
   const state = new Map<string, number>()
   const path: string[] = []
 
-  function dfs(node: string) {
+  function* dfs(node: string): Generator<string[]> {
     state.set(node, 1)
     path.push(node)
 
     for (const dep of adj.get(node) || []) {
-      const depState = state.get(dep) ?? 0
-      if (depState === 1) {
-        // Found a cycle — extract it from the path
-        const cycleStart = path.indexOf(dep)
-        if (cycleStart !== -1) {
-          const cycle = path.slice(cycleStart)
-          cycles.push([...cycle])
-          for (let i = 0; i < cycle.length; i++) {
-            circularNodes.add(cycle[i])
-            const next = cycle[(i + 1) % cycle.length]
-            circularEdges.add(`${cycle[i]}\0${next}`)
-          }
-        }
+      const s = state.get(dep) ?? 0
+      if (s === 1) {
+        const start = path.indexOf(dep)
+        if (start !== -1)
+          yield path.slice(start)
       }
-      else if (depState === 0) {
-        dfs(dep)
+      else if (s === 0) {
+        yield* dfs(dep)
       }
     }
 
@@ -65,10 +45,28 @@ export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResu
 
   for (const mod of modules) {
     if ((state.get(mod.id) ?? 0) === 0)
-      dfs(mod.id)
+      yield* dfs(mod.id)
+  }
+}
+
+/**
+ * Collect all circular dependencies into a single result.
+ * Consumes the generator fully.
+ */
+export function detectCircularDeps(modules: readonly ModuleInfo[]): CircularResult {
+  const nodes = new Set<string>()
+  const edges = new Set<string>()
+  const cycles: string[][] = []
+
+  for (const cycle of findCircularDeps(modules)) {
+    cycles.push([...cycle])
+    for (let i = 0; i < cycle.length; i++) {
+      nodes.add(cycle[i])
+      edges.add(edgeKey(cycle[i], cycle[(i + 1) % cycle.length]))
+    }
   }
 
-  return { nodes: circularNodes, edges: circularEdges, cycles }
+  return { nodes, edges, cycles }
 }
 
 export function edgeKey(from: string, to: string): string {

--- a/src/client/stores/options.ts
+++ b/src/client/stores/options.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 // @keep-sorted
 export interface ViewState {
   diff: boolean
+  graphHighlightCircular: boolean
   graphWeightMode: 'deps' | 'transform' | 'resolveId'
   lineWrapping: boolean
   listMode: 'graph' | 'list' | 'detailed'
@@ -28,6 +29,7 @@ export const useOptionsStore = defineStore('options', () => {
     // @keep-sorted
     {
       diff: true,
+      graphHighlightCircular: true,
       graphWeightMode: 'deps',
       lineWrapping: false,
       listMode: 'detailed',


### PR DESCRIPTION
Detect and visually highlight circular dependencies in the graph view. Circular edges are shown as red dashed lines, and nodes in cycles get a red border. A toggle in the legend panel allows turning highlighting on/off, with a count of detected cycles.

Closes #121

<details>
<summary>circular screenshot</summary>

<img width="1125" height="556" alt="circular screenshot" src="https://github.com/user-attachments/assets/f36ed432-3d34-4237-a1f5-7184f7ac0055" />

</details>

<!-- DO NOT IGNORE THE TEMPLATE! -->

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**.
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community.
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- [x] Read the [Contributing Guide](https://github.com/antfu/contribute).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving and **WHY**.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.