### PR TITLE
test: add regression test for /@fs/ path leak in client build (#169)

### DIFF
--- a/test/client-build.test.ts
+++ b/test/client-build.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build } from 'vite'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const clientRoot = resolve(__dirname, '../src/client')
+const testOutDir = resolve(__dirname, '../dist/__client_build_test__')
+
+beforeAll(async () => {
+  fs.rmSync(testOutDir, { recursive: true, force: true })
+
+  await build({
+    configFile: resolve(clientRoot, 'vite.config.ts'),
+    root: clientRoot,
+    logLevel: 'silent',
+    build: {
+      outDir: testOutDir,
+      emptyOutDir: true,
+    },
+  })
+}, 180_000)
+
+afterAll(() => {
+  fs.rmSync(testOutDir, { recursive: true, force: true })
+})
+
+describe('client build (#169)', () => {
+  it('index.html does not contain a /@fs/ dev-server path', () => {
+    const html = fs.readFileSync(resolve(testOutDir, 'index.html'), 'utf-8')
+    expect(html).not.toContain('/@fs/')
+  })
+
+  it('index.html does not reference @vitejs/devtools inject.js by absolute path', () => {
+    const html = fs.readFileSync(resolve(testOutDir, 'index.html'), 'utf-8')
+    expect(html).not.toMatch(/node_modules.*@vitejs[\\/+]devtools.*inject\.js/)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `test/client-build.test.ts` — a Vitest regression test that runs `vite build` against `src/client/vite.config.ts` into a temp output dir and asserts the generated `index.html` does not contain Vite's dev-server `/@fs/` filesystem prefix or absolute references to `@vitejs/devtools/.../inject.js`, which was the symptom reported in #169.

The bug itself is already fixed upstream — `@vitejs/devtools@0.1.24` (bumped in 8d150e3) gates the `vite:devtools:injection` plugin behind `apply: env.command === 'serve'`, so the test passes on `main` today. It is intended as a forward regression guard. I sanity-verified it catches the bug by temporarily injecting the offending script tag in the client config: the `/@fs/` assertion failed with the exact `<script src="/@fs/...">` from the issue.

Run with `pnpm exec vitest run test/client-build.test.ts`.

## Test plan

- [x] `pnpm exec vitest run test/client-build.test.ts` passes on this branch
- [x] Test fails (catches the regression) when a plugin re-injecting `/@fs/.../inject.js` is added to `src/client/vite.config.ts`